### PR TITLE
added -LO flags to curl requests

### DIFF
--- a/tmux.sh
+++ b/tmux.sh
@@ -10,7 +10,7 @@ set -e
 TMUX_VERSION=1.8
 
 # create our directories
-mkdir tmux_tmp
+mkdir $HOME/tmux_tmp
 cd $HOME/tmux_tmp
 
 # download source files for tmux, libevent, and ncurses

--- a/tmux.sh
+++ b/tmux.sh
@@ -14,9 +14,9 @@ mkdir tmux_tmp
 cd $HOME/tmux_tmp
 
 # download source files for tmux, libevent, and ncurses
-curl -LO https://github.com/tmux/tmux/releases/download/2.3/tmux-2.3.tar.gz
+curl -LO https://github.com/tmux/tmux/releases/download/2.5/tmux-2.5.tar.gz
 curl -LO https://github.com/downloads/libevent/libevent/libevent-2.0.19-stable.tar.gz
-curl -LO ftp://ftp.gnu.org/gnu/ncurses/ncurses-5.9.tar.gz
+curl -LO ftp://ftp.gnu.org/gnu/ncurses/ncurses-6.0.tar.gz
 
 # extract files, configure, and compile
 
@@ -33,8 +33,8 @@ cd ..
 ############
 # ncurses  #
 ############
-tar xvzf ncurses-5.9.tar.gz
-cd ncurses-5.9
+tar xvzf ncurses-6.0.tar.gz
+cd ncurses-6.0
 ./configure --prefix=$HOME/local
 make
 make install
@@ -43,9 +43,8 @@ cd ..
 ############
 # tmux     #
 ############
-tar xvzf tmux-2.3.tar.gz
-cd tmux
--2.3
+tar xvzf tmux-2.5.tar.gz
+cd tmux-2.5
 ./configure CFLAGS="-I$HOME/local/include -I$HOME/local/include/ncurses" LDFLAGS="-L$HOME/local/lib -L$HOME/local/include/ncurses -L$HOME/local/include"
 CPPFLAGS="-I$HOME/local/include -I$HOME/local/include/ncurses" LDFLAGS="-static -L$HOME/local/include -L$HOME/local/include/ncurses -L$HOME/local/lib" make
 cp tmux $HOME/local/bin

--- a/tmux.sh
+++ b/tmux.sh
@@ -14,9 +14,9 @@ mkdir tmux_tmp
 cd $HOME/tmux_tmp
 
 # download source files for tmux, libevent, and ncurses
-curl -o tmux-2.3.tar.gz https://github.com/tmux/tmux/releases/download/2.3/tmux-2.3.tar.gz
-curl -o libevent-2.0.19-stable.tar.gz https://github.com/downloads/libevent/libevent/libevent-2.0.19-stable.tar.gz
-curl -o ncurses-5.9.tar.gz ftp://ftp.gnu.org/gnu/ncurses/ncurses-5.9.tar.gz
+curl -LO https://github.com/tmux/tmux/releases/download/2.3/tmux-2.3.tar.gz
+curl -LO https://github.com/downloads/libevent/libevent/libevent-2.0.19-stable.tar.gz
+curl -LO ftp://ftp.gnu.org/gnu/ncurses/ncurses-5.9.tar.gz
 
 # extract files, configure, and compile
 


### PR DESCRIPTION
previously curl was NOT following HTTP redirects. the -L flag enables this. 
additionally, -O creates output file with same name as file requested. 